### PR TITLE
Fix ActiveRecord 7 deprecation warnings.

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -18,6 +18,7 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/rails_7_0.gemfile
+          - gemfiles/rails_6_1.gemfile
           - gemfiles/rails_6_0.gemfile
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Fixed] Fix ActiveRecord 7 deprecation warnings.
+
 ## v2.0.1 - 2021-12-11
 
-- [Fixed] Rails 7 was raising an exception because 
+- [Fixed] Rails 7 was raising an exception because
   `ActionView::Base.raise_on_missing_translations` is not a thing anymore.
 
 ## v2.0.0 - 2021-12-06

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec path: ".."
-
-gem "rails", "~> 5.0.0"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec path: ".."
-
-gem "rails", "~> 5.2.0"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec path: ".."
+
+gem "rails", "~> 6.1.0"

--- a/rails-env.gemspec
+++ b/rails-env.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-fnando"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "sqlite3"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,9 +4,11 @@ require "simplecov"
 SimpleCov.start
 
 ENV["RAILS_ENV"] = "test"
+ENV["DATABASE_URL"] = "sqlite3::memory:"
 
 require "bundler/setup"
 require "rails"
+require "active_record/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "action_controller/railtie"

--- a/test/unit/rails_test.rb
+++ b/test/unit/rails_test.rb
@@ -59,9 +59,31 @@ class ConfigPropagationTest < Minitest::Test
     assert_equal [:"pt-BR"], I18n.available_locales
   end
 
-  RailsEnv.with_rails_constraint("< 7.0.0") do
+  RailsEnv.with_rails_constraint([">= 6.1.0", "< 7.0.0"]) do
     test "sets raise on missing translations" do
       assert ActionView::Base.raise_on_missing_translations
+    end
+
+    test "sets active record option" do
+      Rails.env.on(:test) do
+        config.active_record.dump_schema_after_migration = false
+        config.active_record.legacy_connection_handling = false
+      end
+
+      refute ActiveRecord::Base.dump_schema_after_migration
+      refute ActiveRecord::Base.legacy_connection_handling
+    end
+  end
+
+  RailsEnv.with_rails_constraint(">= 7.0.0") do
+    test "sets active record option" do
+      Rails.env.on(:test) do
+        config.active_record.dump_schema_after_migration = false
+        config.active_record.legacy_connection_handling = false
+      end
+
+      refute ActiveRecord.dump_schema_after_migration
+      refute ActiveRecord.legacy_connection_handling
     end
   end
 


### PR DESCRIPTION
Configuration is now performed on `ActiveRecord` rather than
`ActiveRecord::Base`.

<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [ ] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand
the why.]

### Known limitations

[TODO or N/A]
